### PR TITLE
Update README port and utils info

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,6 @@ src/
 ├── infrastructure/    // Mock data and stores
 ├── routes/            // API route definitions
 ├── types/             // TypeScript interfaces and types
-├── utils/             // Utility functions
 └── index.ts           // Application entry point
 ```
 
@@ -83,7 +82,7 @@ npm run dev
 yarn dev
 ```
 
-The server will start on `http://localhost:8080`.
+The server listens on `http://localhost:3000` by default. You can override this by setting the `PORT` environment variable.
 
 ## 📚 API Reference
 


### PR DESCRIPTION
## Summary
- fix port information
- remove outdated `utils` reference

## Testing
- `npm run lint` *(fails: Cannot use import statement outside a module)*

------
https://chatgpt.com/codex/tasks/task_e_6841a5d66e488323af0210d6967c32ce